### PR TITLE
Add toggle button to hide main menu

### DIFF
--- a/src/init/body.ts
+++ b/src/init/body.ts
@@ -174,6 +174,11 @@ Corona.ReloadCorona = (): void => {
 		delete Corona.Panels.MainPanel
 	}
 
+	if(Corona.Panels.MenuButton) {
+		Corona.Panels.MenuButton.DeleteAsync(0)
+		delete Corona.Panels.MenuButton
+	}
+
 	Corona.ServerRequest("scriptlist")
 		.then(response => Promise.all(response.map(str => `${str}/body`).map(Corona.GetScript)))
 		.then(scriptsCode => {
@@ -269,6 +274,17 @@ Corona.LoadCorona = (): Promise<void> => new Promise(resolve => {
 		Corona.Panels.MainPanel.DeleteAsync(0)
 		delete Corona.Panels.MainPanel
 	}
+
+	var menuButtons = Corona.Panels.Main.HUDElements.FindChild('MenuButtons').FindChild('ButtonBar')
+	Corona.Panels.MenuButton = $.CreatePanel("Button", menuButtons, "ToggleCoronaButton")
+	Corona.Panels.MenuButton.BLoadLayoutFromString(`
+		<root>\
+			<Button style="background-image: url('s2r://panorama/images/control_icons/guild_leader_png.vtex'); background-size: 26px;"/>\
+		</root>
+	`, false, false)
+	Corona.Panels.MenuButton.SetPanelEvent("onactivate", () => {
+		Corona.Panels.MainPanel.visible = !Corona.Panels.MainPanel.visible
+	})
 
 	Corona.Panels.MainPanel = $.CreatePanel("Panel", Corona.Panels.Main, "DotaOverlay")
 	Corona.GetXML("init/hud").then(layout_String => {
@@ -393,6 +409,7 @@ function WaitForGameStart(): void {
 			Game.AddCommand("_MouseDown", () => ChangeCamDist(cam_dist_struct.lastValue + (GameUI.IsControlDown() ? 25 : 0)), "", 0)
 			Game.AddCommand("__ReloadCorona", Corona.ReloadCorona, "", 0)
 			Game.AddCommand("__TogglePanel", () => Corona.Panels.MainPanel.visible = !Corona.Panels.MainPanel.visible, "",0)
+			Game.AddCommand("__ToggleMenuButton", () => Corona.Panels.MenuButton.visible = !Corona.Panels.MenuButton.visible, "",0)
 			Game.AddCommand("__eval", (name, code) => $.Msg("__eval", eval(code)), "", 0)
 			Game.AddCommand("__ToggleMinimapActs", () => Corona.Panels.Main.HUDElements.FindChildTraverse("GlyphScanContainer").visible = MinimapActsEnabled = !MinimapActsEnabled, "",0)
 			Game.AddCommand("__ToggleStats", () => Corona.Panels.Main.HUDElements.FindChildTraverse("quickstats").visible = StatsEnabled = !StatsEnabled, "",0)

--- a/src/init/hud.xml
+++ b/src/init/hud.xml
@@ -1,42 +1,41 @@
 <root>
 	<styles>
-		<include src="s2r://panorama/styles/dotastyles.css"/>
+		<include src="s2r://panorama/styles/dotastyles.css" />
 		<include src='s2r://panorama/styles/popups/popups_shared.vcss_c' />
 		<include src='s2r://panorama/styles/battle_pass/current_battle_pass.vcss_c' />
 		<include src='s2r://panorama/styles/popups/popup_settings.vcss_c' />
 	</styles>
 
-	<Panel draggable="true" >
-		  
-	
-		<Panel id="Main" >
-	
-		<Panel id="top-menu">
-		<Image src='https://i.imgur.com/Oec9AjJ.png' style='width: 250px; height: 30px;'/>
-		</Panel>
-		
-			<Label id="ScriptsName" text="Corona v 0.2.1" style='width: 250px;'/>
-				<Panel id="logo">
-		<Image src='https://i.imgur.com/9Lgj8AF.png' style='width: 250px; height: 125px;'/>
-			<!-- <Image src='https://i.ibb.co/gFWCXCP/observer-ward.png' style='width: 80px; height: 80px;'/> -->
-		</Panel>
-		
+	<Panel draggable="true">
+
+		<Panel id="Main">
+
+			<Panel id="top-menu">
+				<Image src='https://i.imgur.com/Oec9AjJ.png' style='width: 250px; height: 30px;' />
+			</Panel>
+
+			<Label id="ScriptsName" text="Corona v 0.2.2" style='width: 250px;' />
+			<Panel id="logo">
+				<Image src='https://i.imgur.com/9Lgj8AF.png' style='width: 250px; height: 125px;' />
+				<!-- <Image src='https://i.ibb.co/gFWCXCP/observer-ward.png' style='width: 80px; height: 80px;'/> -->
+			</Panel>
+
 			<Panel id="Overlay">
-				<Panel id="scripts"/>
+				<Panel id="scripts" />
 			</Panel>
 			<Button id="Reload">
-				<Label id="ReloadText" text="Reload scripts"/>
+				<Label id="ReloadText" text="Reload scripts" />
 			</Button>
-		
-			<Label id="ScriptLogName" text="Script log"/>
-			<Panel id="ScriptLog"/>
+
+			<Label id="ScriptLogName" text="Script log" />
+			<Panel id="ScriptLog" />
 			<Panel id="bottom-menu">
-		<Image src='https://i.imgur.com/esdVn83.png' style='width: 250px; height: 10px;'/>
-		</Panel>
+				<Image src='https://i.imgur.com/esdVn83.png' style='width: 250px; height: 10px;' />
+			</Panel>
 		</Panel>
 		<!-- <Button id="QuestSlideThumb" class="PanelSlideThumb">
 		<Panel class="PanelSlideThumbArrow"/>
 		</Button> -->
-		
+
 	</Panel>
 </root>


### PR DESCRIPTION
# A small step towards a major GUI change
- Added a button to activate and deactivate the menu.
- Added an additional configuration to hide the menu via the '__ToggleMenuButton' console.
- I took advantage and passed the eslint HTML in hud.xml.

![image](https://user-images.githubusercontent.com/40774281/83932610-1d70c580-a77a-11ea-9542-da099b26defa.png)
